### PR TITLE
Some fixes at V0_Display

### DIFF
--- a/V0_Display/Documentation/Assembly_Guide.md
+++ b/V0_Display/Documentation/Assembly_Guide.md
@@ -15,7 +15,7 @@ This is **NOT** an instruction manual. While the components here were picked as 
 	- If there are shorts, examine the components for solder bridges and recheck.
 	- If there are no shorts, continue.
 
-- Plug board into Pi and follow the [Setup guide](Setup_Guide.md) until step 5 to verify that the MCU is operational and detected.
+- Plug board into Pi and follow the [Setup guide](Setup_and_Flashing_Guide.md) until step 5 to verify that the MCU is operational and detected.
 
 - Finish the SMD assembly by installing the:
 	- Neopixel buffer (U3)

--- a/V0_Display/Software/DisplayButtons.cfg
+++ b/V0_Display/Software/DisplayButtons.cfg
@@ -15,7 +15,7 @@ kill_pin: ^displayButtons:PA5
 [neopixel status]
 pin: displayButtons:PA0
 chain_count: 1
-color_order_GRB: True
+color_order: RGB
 initial_RED: 0.4
 initial_GREEN: 0.1
 initial_BLUE: 0.0

--- a/V0_Display/Software/DisplayButtons.cfg
+++ b/V0_Display/Software/DisplayButtons.cfg
@@ -10,7 +10,7 @@ click_pin: ^displayButtons:PA2
 back_pin: ^displayButtons:PA3
 up_pin: ^displayButtons:PA1
 down_pin: ^displayButtons:PA4
-kill_pin: ^displayButtons:PA5
+kill_pin: ^!displayButtons:PA5
 
 [neopixel status]
 pin: displayButtons:PA0

--- a/V0_Display/Software/DisplayButtons.cfg
+++ b/V0_Display/Software/DisplayButtons.cfg
@@ -15,7 +15,7 @@ kill_pin: ^!displayButtons:PA5
 [neopixel status]
 pin: displayButtons:PA0
 chain_count: 1
-color_order: RGB
+color_order: GRB
 initial_RED: 0.4
 initial_GREEN: 0.1
 initial_BLUE: 0.0

--- a/V0_Display/Software/DisplayEncoder.cfg
+++ b/V0_Display/Software/DisplayEncoder.cfg
@@ -13,7 +13,7 @@ kill_pin: ^!displayEncoder:PA5
 [neopixel displayStatus]
 pin: displayEncoder:PA0
 chain_count: 1
-color_order_GRB: True
+color_order: RGB
 initial_RED: 0.2
 initial_GREEN: 0.05
 initial_BLUE: 0

--- a/V0_Display/Software/DisplayEncoder.cfg
+++ b/V0_Display/Software/DisplayEncoder.cfg
@@ -13,7 +13,7 @@ kill_pin: ^!displayEncoder:PA5
 [neopixel displayStatus]
 pin: displayEncoder:PA0
 chain_count: 1
-color_order: RGB
+color_order: GRB
 initial_RED: 0.2
 initial_GREEN: 0.05
 initial_BLUE: 0


### PR DESCRIPTION
- Fixed Link to Setup guide at Assemblx_Guide.md

- Change "color_order_GRB" to "color_order" 
> 20201029: The neopixel color_order_GRB config option has been removed. If necessary, update the config to set the new color_order option to RGB, GRB, RGBW, or GRBW.

- Inverted "kill_pin" in DisplayButtons.cfg