### PR TITLE
Correct a typo in setup guide

### DIFF
--- a/V0_Display/Documentation/Setup_and_Flashing_Guide.md
+++ b/V0_Display/Documentation/Setup_and_Flashing_Guide.md
@@ -22,7 +22,7 @@
 	
 6) Remove the boot jumper.
 
-7) Run `CD ~/klipper` from the command line to enter the Klipper directory
+7) Run `cd ~/klipper` from the command line to enter the Klipper directory
 
 8) Run `make menuconfig` settings should be:
 


### PR DESCRIPTION
`CD ~/klipper` should be `cd ~/klipper`  this trips up the copy/pasters.