### PR TITLE
Update DisplayEncoder.cfg to change default direction of encoder wheel

### DIFF
--- a/V0_Display/Software/DisplayEncoder.cfg
+++ b/V0_Display/Software/DisplayEncoder.cfg
@@ -6,7 +6,11 @@ restart_method: command
 lcd_type: sh1106
 i2c_mcu: displayEncoder
 i2c_bus: i2c1a
-encoder_pins: ^displayEncoder:PA4, ^displayEncoder:PA3
+# Set the direction of the encoder wheel
+#   Standard: Right (clockwise) scrolls down or increases values. Left (counter-clockwise scrolls up or decreases values.
+encoder_pins: ^displayEncoder:PA3, ^displayEncoder:PA4
+#   Reversed: Right (clockwise) scrolls up or decreases values. Left (counter-clockwise scrolls down or increases values.
+#encoder_pins: ^displayEncoder:PA4, ^displayEncoder:PA3
 click_pin: ^!displayEncoder:PA1
 kill_pin: ^!displayEncoder:PA5
 #x_offset: 2


### PR DESCRIPTION
The default direction of the encoder wheel is backwards, IMO.  Normally, turning the wheel clockwise (to the right) should scroll down or increase values.  The default behavior decreases values when turning clockwise (or scrolls up).  This change sets the default to normal behavior and explains to the user how to change it.  Big thanks to Weaslus for telling me how to fix it for myself!