### PR TITLE
Update nano_display pin definitions

### DIFF
--- a/Nano_Display/Software/nano_mini12864.cfg
+++ b/Nano_Display/Software/nano_mini12864.cfg
@@ -3,42 +3,29 @@
 [mcu display]
 #    mcu for the display
 serial: ADD YOUR PATH HERE
-pin_map: arduino
 restart_method: arduino
 
 [display]
 lcd_type: uc1701
-cs_pin: display:EXP1_3
-a0_pin: display:EXP1_4
-rst_pin: display:EXP1_5
+cs_pin: display:PD6
+a0_pin: display:PD7
+rst_pin: display:PD4
 contrast: 63
-encoder_pins: ^display:EXP2_5, ^display:EXP2_3
-click_pin: ^!display:EXP1_2
+encoder_pins: ^display:PC4, ^display:PC2
+click_pin: ^!display:PB1
 ## Some micro-controller boards may require an spi bus to be specified:
 #spi_bus: spi
 ## Alternatively, some micro-controller boards may work with software spi:
-#spi_software_miso_pin: display:EXP2_1
-#spi_software_mosi_pin: display:EXP2_6
-#spi_software_sclk_pin: display:EXP2_2
+spi_software_miso_pin: display:EXP2_1
+spi_software_mosi_pin: display:EXP2_6
+spi_software_sclk_pin: display:EXP2_2
 
 [output_pin beeper]
-pin: display:EXP1_1
+pin: display:PB0
 
 [neopixel fysetc_mini12864]
-pin: display:EXP1_6
+pin: display:PD5
 chain_count: 3
-color_order_GRB: False
-initial_RED: 0.0
-initial_GREEN: 0.0
-initial_BLUE: 0.9
-
-[board_pins display]
-aliases:
-    # Common EXP1 header found on many "all-in-one" ramps clones
-    EXP1_1=ar8,  EXP1_3=ar6,  EXP1_5=ar4,  EXP1_7=ar2,  EXP1_9=<GND>,
-    EXP1_2=ar9,  EXP1_4=ar7,  EXP1_6=ar5,  EXP1_8=ar3,  EXP1_10=<5V>,
-    # EXP2 header
-    EXP2_1=ar12, EXP2_3=ar16, EXP2_5=ar18, EXP2_7=<GND>, EXP2_9=<GND>,
-    EXP2_2=ar13, EXP2_4=ar17, EXP2_6=ar11, EXP2_8=<RST>,EXP2_10=ar19
-    # Pins EXP2_1, EXP2_6, EXP2_2 are also MISO, MOSI, SCK of bus "spi"
-    # Note, some boards wire: EXP2_8=<RST>, EXP2_10=ar41
+initial_RED: 0.9
+initial_GREEN: 0.06
+initial_BLUE: 0.0

--- a/Nano_Display/Software/nano_reprap12864.cfg
+++ b/Nano_Display/Software/nano_reprap12864.cfg
@@ -3,29 +3,16 @@
 [mcu display]
 #    mcu for the display
 serial: ADD YOUR PATH HERE
-pin_map: arduino
 restart_method: arduino
 
 # For the Mini 12864 Display. Copy your display from https://github.com/KevinOConnor/klipper/blob/master/config/sample-lcd.cfg
 [display]  
 lcd_type: st7920
-cs_pin: display:EXP1_4
-sclk_pin: display:EXP1_5
-sid_pin: display:EXP1_3
-encoder_pins: ^display:EXP2_3, ^display:EXP2_5
-click_pin: ^!display:EXP1_2
-#kill_pin: ^!display:EXP2_8
+cs_pin: display:PD7
+sclk_pin: display:PD4
+sid_pin: display:PD6
+encoder_pins: ^display:PC2, ^display:PC4
+click_pin: ^!display:PB1
 
 [output_pin beeper]
-pin: display:EXP1_1
-
-[board_pins display]
-aliases:
-    # Common EXP1 header found on many "all-in-one" ramps clones
-    EXP1_1=ar8,  EXP1_3=ar6,  EXP1_5=ar4,  EXP1_7=ar2,  EXP1_9=<GND>,
-    EXP1_2=ar9,  EXP1_4=ar7,  EXP1_6=ar5,  EXP1_8=ar3,  EXP1_10=<5V>,
-    # EXP2 header
-    EXP2_1=ar12, EXP2_3=ar16, EXP2_5=ar18, EXP2_7=<GND>, EXP2_9=<GND>,
-    EXP2_2=ar13, EXP2_4=ar17, EXP2_6=ar11, EXP2_8=<RST>,EXP2_10=ar19
-    # Pins EXP2_1, EXP2_6, EXP2_2 are also MISO, MOSI, SCK of bus "spi"
-    # Note, some boards wire: EXP2_8=<RST>, EXP2_10=ar41
+pin: display:PB0


### PR DESCRIPTION
pin_map was deprecated and is now being removed from Klipper