### PR TITLE
Update klipper-mini12864.cfg

### DIFF
--- a/STM32_Mini12864/klipper-mini12864.cfg
+++ b/STM32_Mini12864/klipper-mini12864.cfg
@@ -1,7 +1,7 @@
 [mcu menu]
 # Uncomment serial and update with proper path
 # Find serial path by running terminal command: ls /dev/serial/by-id/*
-#serial: /dev/serial/by-id/usb-Klipper_stm32f042x6_
+#serial: **PASTE YOUR SERIAL PORT HERE AND UNCOMMENT**
 restart_method: command
 
 [display]

--- a/STM32_Mini12864/klipper-mini12864.cfg
+++ b/STM32_Mini12864/klipper-mini12864.cfg
@@ -1,6 +1,7 @@
 [mcu menu]
 # Uncomment serial and update with proper path
-#serial: /dev/ttyACM0
+# Find serial path by running terminal command: ls /dev/serial/by-id/*
+#serial: /dev/serial/by-id/usb-Klipper_stm32f042x6_
 restart_method: command
 
 [display]
@@ -23,14 +24,18 @@ cycle_time: 0.001
 scale: 1000
  
 [gcode_macro M300]
-default_parameter_S=1000
-default_parameter_P=100
-gcode:  SET_PIN PIN=BEEPER_pin VALUE={S}
-        G4 P{P}
-        SET_PIN PIN=BEEPER_pin VALUE=0
+gcode:
+    # Use a default 1kHz tone if S is omitted.
+    {% set S = params.S|default(1000)|int %}
+    # Use a 10ms duration is P is omitted.
+    {% set P = params.P|default(100)|int %}
+    SET_PIN PIN=BEEPER_pin VALUE={S} CYCLE_TIME={ 1.0/S if S > 0 else 1 }
+    G4 P{P}
+    SET_PIN PIN=BEEPER_pin VALUE=0
 
-
-[neopixel np]
+# name of neopixel should match name referenced in printer.cfg
+# if there are other gcode_macros referencing the led display (e.g delayed gcode_macro)
+[neopixel fysetc_mini12864]
 pin: menu:PA13
 chain_count: 3
 color_order: RGB


### PR DESCRIPTION
Revised gcode_macro M300 syntax for parameter S & P callout depreciated/removed per Klipper configuration change on 20211102.

Old Syntax:
default_parameter_S=1000
default_parameter_P=100

New Syntax:
{% set S = params.S|default(1000)|int %}
{% set P = params.P|default(100)|int %}

Also added comments/hints to find serial path by-id and to match neopixel name with led name referenced in printer.cfg (if led name is also used in a printer.cfg gcode_macro.