### PR TITLE
Update sensor_type in example config for V0-Umbilical

### DIFF
--- a/V0-Umbilical/Software/Umbilical.cfg
+++ b/V0-Umbilical/Software/Umbilical.cfg
@@ -2,6 +2,6 @@
 # Thanks to Mike | V0.557#8668 for finding the extra pins you can use
 
 [temperature_sensor Chamber_Temp]
-sensor_type: NTC 100K beta 3950
+sensor_type: Generic 3950
 sensor_pin: PA7 # PA7 is MOSI on the SPI header. Has an on board 10K pullup to 3v3. Connect other leg of thermistor to ground
 pullup_resistor: 10000


### PR DESCRIPTION
replace sensor_type `NTC 100K beta 3950` with `Generic 3950`  in V0-Umbilical example config