### PR TITLE
Daylight | typo in the BOM

### DIFF
--- a/Daylight/Daylight_on_a_matchstick/README.md
+++ b/Daylight/Daylight_on_a_matchstick/README.md
@@ -5,7 +5,7 @@
 ## BOM
 | Quantity | Value                         | Package |
 |----------|-------------------------------|---------|
-|        4 | 100k Resistor                 | 1210    |
+|        4 | 100 Ohms Resistor             | 1210    |
 |       12 | White LED (4000K, 90+ CRI)    | 2835    |
 |        2 | JST-XH (2.54) angled connector| 2pin    |
 

--- a/Daylight/Daylight_on_a_stick/README.md
+++ b/Daylight/Daylight_on_a_stick/README.md
@@ -5,7 +5,7 @@
 ## BOM
 | Quantity | Value                         | Package |
 |----------|-------------------------------|---------|
-|        6 | 100k Resistor                 | 1210    |
+|        6 | 100 Ohms Resistor             | 1210    |
 |       18 | White LED (4000K, 90+ CRI)    | 2835    |
 |        2 | JST-XH (2.54) angled connector| 2pin    |
 


### PR DESCRIPTION
The resistors should be 100R not 100K
Assembly files for JLCPCB were correct, as is the KiCad project. Just the readme had a typo.