### PR TITLE
Fix 100Ω resistor (was 100K)

### DIFF
--- a/Daylight/Daylight_on_a_stick_XXL/README.md
+++ b/Daylight/Daylight_on_a_stick_XXL/README.md
@@ -6,7 +6,7 @@ Meant for 350 size printers.
 ## BOM
 | Quantity | Value                         | Package |
 |----------|-------------------------------|---------|
-|       10 | 100k Resistor                 | 1210    |
+|       10 | 100Ω Resistor                 | 1210    |
 |       30 | White LED (4000K, 90+ CRI)    | 2835    |
 |        2 | JST-XH (2.54) angled connector| 2pin    |
 


### PR DESCRIPTION
- Fixed the BOM to read 100Ω instead of 100k (like in the other daylight sticks!)