### PR TITLE
Fix BOM callouts for SKR Mini E3 V3.0 screen adaptor.

### DIFF
--- a/SKR-Mini_Screen_Adaptor/SRK Mini E3 V3.0/README.md
+++ b/SKR-Mini_Screen_Adaptor/SRK Mini E3 V3.0/README.md
@@ -12,9 +12,10 @@
 ## Parts list:
   - 2 x 2x5 [male pin shielded header](https://www.amazon.com/HONJIE-10Pins-Straight-Connector-Headers/dp/B0834RR68V/ref=sr_1_1) (bare male header pins can also work)
   - 1 x 2x5 [female header pin strip](https://www.amazon.com/Double-Female-Straight-Header-Socket/dp/B00R1LKZOM/ref=sr_1_2)
-  - 1 x 2x3 [female header pin strip](https://www.amazon.com/Connectors-Pro-2-54mm-PCB-Through-Board/dp/B08R8LGM4L/ref=sr_1_2) (both can be cut from a single [dual pin header strip](https://www.amazon.com/Antrader-2-54mm-2x20Pin-Female-Connector/dp/B07D48WZTR/ref=sr_1_3))
- 
- 
+  - 1 x 2x4 [female header pin strip](https://www.amazon.com/Connectors-Pro-Straight-Through-Board-Connector/dp/B08R8HBLP6/ref=sr_1_3)
+  	- Both female header pins can also be cut from [dual pin header strip](https://www.amazon.com/Antrader-2-54mm-2x20Pin-Female-Connector/dp/B07D48WZTR/ref=sr_1_3))
+
+
  # Changelog:
   - Rev: B
 	- Update hole sizing on 2x5 pin shrouded header (0.75 -> 1.0mm)


### PR DESCRIPTION
The SKR Mini E3 V3 screen adaptor called out a 2x3 pin header when it meant to be a 2.4